### PR TITLE
fix: 게시글 목록에서 게시글 클릭 시 해당 게시물 상세 페이지로 이동

### DIFF
--- a/src/containers/mypage/MyBoardListContainer.js
+++ b/src/containers/mypage/MyBoardListContainer.js
@@ -18,7 +18,7 @@ const MyBoardListContainer = () => {
     }, [dispatch]);
 
     const onNavigateDetail = (boardId) => {
-        navigate(`${boardId}`);
+        navigate(`/boards/${boardId}`);
     };
 
     return (


### PR DESCRIPTION
- 변경 전 : navigate(`boards/${boardId}`)
현재 경로 뒤에 **설정한 경로**가 붙는다. 
ex) 현재 경로가 mypage/boards 라면, mypage/boards/boards/1 

- 변경 후 : navigate(`/boards/${boardId}`)
**설정한 경로**로 이동한다.
ex) boards/1
