### PR TITLE
refactor: 게시글 목록 컴포넌트를 공통 컴포넌트로 분리하여 재사용

### DIFF
--- a/src/components/boards/AllBoardList.js
+++ b/src/components/boards/AllBoardList.js
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import BoardList from "../common/BoardList";
+
+const SelectBox = styled.select`
+  margin-top: 1rem;
+  margin-right: 10rem;
+  float: right;
+
+`;
+
+const AllBoardList = ({boards, boardsError, loading, onSelectFilter, onNavigateDetail}) => {
+    if (boardsError) {
+        return <div>에러 발생!</div>
+    }
+
+    return (
+        <>
+            <SelectBox onChange={e => onSelectFilter(e)}>
+                <option value="">== 정렬 기준 ==</option>
+                <option key="latest" value="latest">최신순</option>
+                <option key="likes" value="likes">좋아요순</option>
+                <option key="views" value="views">조회수순</option>
+            </SelectBox>
+            <BoardList boards={boards} loading={loading} onNavigateDetail={onNavigateDetail}/>
+        </>
+    );
+};
+
+export default AllBoardList;

--- a/src/components/common/BoardList.js
+++ b/src/components/common/BoardList.js
@@ -1,7 +1,8 @@
-import styled from "styled-components";
-import {BiShow} from "react-icons/bi";
 import ThumbNail from "../../assets/thumbNail.jpg";
 import FillLike from "../../assets/fill.png";
+import {BiShow} from "react-icons/bi";
+import styled from "styled-components";
+import {useNavigate} from "react-router-dom";
 
 const BoardListBlock = styled.div`
   padding-right: 1rem;
@@ -72,13 +73,6 @@ const LikeImage = styled.img`
   object-fit: cover;
 `;
 
-const SelectBox = styled.select`
-  margin-top: 1rem;
-  margin-right: 10rem;
-  float: right;
-
-`;
-
 const BoardCard = ({board, onNavigateDetail}) => {
     const {title, writer, createdAt, likeCount, views} = board;
 
@@ -98,29 +92,22 @@ const BoardCard = ({board, onNavigateDetail}) => {
     );
 };
 
-const BoardList = ({boards, boardsError, loading, onSelectFilter, onNavigateDetail}) => {
-    if (boardsError) {
-        return <BoardListBlock>에러 발생!</BoardListBlock>
-    }
+const BoardList = ({boards, loading}) => {
+    const navigate = useNavigate();
+    const onNavigateDetail = (boardId) => {
+        navigate(`/boards/${boardId}`);
+    };
 
     return (
-        <>
-            <SelectBox onChange={e => onSelectFilter(e)}>
-                <option value="">== 정렬 기준 ==</option>
-                <option key="latest" value="latest">최신순</option>
-                <option key="likes" value="likes">좋아요순</option>
-                <option key="views" value="views">조회수순</option>
-            </SelectBox>
-            <BoardListBlock>
-                {!loading && boards && (
-                    <div>
-                        {boards.data.content.map(board => (
-                            <BoardCard board={board} key={board.id} onNavigateDetail={() => onNavigateDetail(board.id)}/>
-                        ))}
-                    </div>
-                )}
-            </BoardListBlock>
-        </>
+        <BoardListBlock>
+            {!loading && boards && (
+                <div>
+                    {boards.data.content.map(board => (
+                        <BoardCard board={board} key={board.id} onNavigateDetail={() => onNavigateDetail(board.id)}/>
+                    ))}
+                </div>
+            )}
+        </BoardListBlock>
     );
 };
 

--- a/src/components/mypage/MyBoardList.js
+++ b/src/components/mypage/MyBoardList.js
@@ -1,111 +1,12 @@
-import styled from "styled-components";
-import {BiShow} from "react-icons/bi";
-import ThumbNail from "../../assets/thumbNail.jpg";
-import FillLike from "../../assets/fill.png";
+import BoardList from "../common/BoardList";
 
-const MyBoardListBlock = styled.div`
-  padding-right: 1rem;
-  padding-left: 1rem;
-  margin: 0 auto;
-  margin-top: 3rem;
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-`;
-
-const BoardCardBlock = styled.div`
-  width: 320px;
-  height: 360px;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  flex-grow: 0;
-  max-width: 100%;
-  background-color: #fff;
-  box-shadow: 0 5px 10px 5px #f2f5f7;
-  border-radius: 10px;
-  border: 1px solid #f2f5f7;
-  overflow: hidden;
-  margin: 3rem 1.5rem;
-  cursor: pointer;
-
-  h2 {
-    font-size: 2rem;
-    margin: 0.5rem 0;
-    padding-left: 0.6rem;
-  }
-`;
-
-const BoardImage = styled.img`
-  position: relative;
-  width: 100%;
-  height: 56.25%;
-  object-fit: cover;
-`;
-
-const SubInfo = styled.div`
-  padding-left: 0.6rem;
-
-  span + span:before {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-    content: '\\B7';
-  }
-`;
-
-const CountInfo = styled.div`
-  padding-left: 0.6rem;
-  margin-top: 2.5rem;
-
-  span + span {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
-`;
-
-const LikeImage = styled.img`
-  width: 18px;
-  height: 18px;
-  object-fit: cover;
-`;
-
-const BoardCard = ({board, onNavigateDetail}) => {
-    const {title, writer, createdAt, likeCount, views} = board;
-
-    return (
-        <BoardCardBlock onClick={onNavigateDetail}>
-            <BoardImage src={ThumbNail}/>
-            <h2><b>{title}</b></h2>
-            <SubInfo>
-                <span>{writer}</span>
-                <span>{new Date(createdAt).toLocaleString()}</span>
-            </SubInfo>
-            <CountInfo>
-                <span><LikeImage src={FillLike}/>{likeCount}</span>
-                <span><BiShow/>{views}</span>
-            </CountInfo>
-        </BoardCardBlock>
-    );
-};
-
-const MyBoardList = ({myBoardList, myBoardListError, loading, onNavigateDetail}) => {
+const MyBoardList = ({myBoardList, myBoardListError, loading}) => {
     if (myBoardListError) {
-        return <MyBoardListBlock>에러 발생!</MyBoardListBlock>
+        return <div>에러 발생!</div>
     }
 
     return (
-            <MyBoardListBlock>
-                {!loading && myBoardList && (
-                    <div>
-                        {myBoardList.data.content.map(board => (
-                            <BoardCard board={board} key={board.id} onNavigateDetail={() => onNavigateDetail(board.id)}/>
-                        ))}
-                    </div>
-                )}
-            </MyBoardListBlock>
+        <BoardList boards={myBoardList} loading={loading}/>
     );
 };
 

--- a/src/containers/boards/AllBoardListContainer.js
+++ b/src/containers/boards/AllBoardListContainer.js
@@ -1,12 +1,11 @@
-import BoardList from "../../components/boards/BoardList";
+import AllBoardList from "../../components/boards/AllBoardList";
 import {useDispatch, useSelector} from "react-redux";
 import {useEffect} from "react";
 import {boardList} from "../../modules/boards";
-import {useNavigate, useSearchParams} from "react-router-dom";
+import {useSearchParams} from "react-router-dom";
 
-const BoardListContainer = () => {
+const AllBoardListContainer = () => {
     const [searchParams] = useSearchParams();
-    const navigate = useNavigate();
     const condition = searchParams.get('sortBy');
     const dispatch = useDispatch();
     const {boards, boardsError, loading} = useSelector(({boards, loading}) => ({
@@ -24,18 +23,13 @@ const BoardListContainer = () => {
         dispatch(boardList(value));
     };
 
-    const onNavigateDetail = (boardId) => {
-        navigate(`boards/${boardId}`);
-    };
-
     return (
-        <BoardList boards={boards}
-                   boardsError={boardsError}
-                   loading={loading}
-                   onSelectFilter={onSelectFilter}
-                   onNavigateDetail={onNavigateDetail}
+        <AllBoardList boards={boards}
+                      boardsError={boardsError}
+                      loading={loading}
+                      onSelectFilter={onSelectFilter}
         />
     );
 };
 
-export default BoardListContainer;
+export default AllBoardListContainer;

--- a/src/containers/mypage/MyBoardListContainer.js
+++ b/src/containers/mypage/MyBoardListContainer.js
@@ -2,10 +2,8 @@ import MyBoardList from "../../components/mypage/MyBoardList";
 import {useDispatch, useSelector} from "react-redux";
 import {useEffect} from "react";
 import {myBoardList} from "../../modules/mypage";
-import {useNavigate} from "react-router-dom";
 
 const MyBoardListContainer = () => {
-    const navigate = useNavigate();
     const dispatch = useDispatch();
     const {my, myError, loading} = useSelector(({myPage, loading}) => ({
         my: myPage.my,
@@ -17,15 +15,10 @@ const MyBoardListContainer = () => {
         dispatch(myBoardList());
     }, [dispatch]);
 
-    const onNavigateDetail = (boardId) => {
-        navigate(`/boards/${boardId}`);
-    };
-
     return (
         <MyBoardList myBoardList={my}
                      myBoardListError={myError}
                      loading={loading}
-                     onNavigateDetail={onNavigateDetail}
         />
     );
 };

--- a/src/pages/BoardListPage.js
+++ b/src/pages/BoardListPage.js
@@ -1,26 +1,8 @@
-import BoardListContainer from "../containers/boards/BoardListContainer";
+import AllBoardListContainer from "../containers/boards/AllBoardListContainer";
 
 const BoardListPage = () => {
-    /*const options = [
-        {
-            name: "최신",
-            value: "latest"
-        },
-        {
-            name: "조회수",
-            value: "views"
-        },
-        {
-            name: "좋아요",
-            value: "likes"
-        }
-    ];*/
-
     return (
-        <div>
-            {/*<SortBox options={options}/>*/}
-            <BoardListContainer/>
-        </div>
+        <AllBoardListContainer/>
     );
 };
 


### PR DESCRIPTION
- 기존
: 여러 페이지에서 같은 코드를 중복하여 사용

- 변경 후
: 게시글 목록 컴포넌트를 공통 컴포넌트로 분리하여 전체 게시글 목록 페이지 혹은 내가 작성한 게시글 목록 페이지에서 재사용하여 코드 중복 제거
: 게시글 목록에서 특정 게시글 클릭 시, 해당 게시글 상세 페이지로 이동하는 함수(onNavigateDetail)도 common/BoardList 컴포넌트에 선언하여 코드 중복 제거