### PR TITLE
feat: 헤더 생성

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,4 @@
-.App {
-  text-align: center;
-}
-
+@import url('https://fonts.googleapis.com/css2?family=Gaegu:wght@700&family=Merriweather:wght@700&family=Noto+Sans+KR:wght@400;500;700&family=Roboto:ital,wght@0,300;0,700;1,400&family=Sunflower:wght@500&family=Tilt+Neon&family=Young+Serif&display=swap');
 .App-logo {
   height: 40vmin;
   pointer-events: none;

--- a/src/App.js
+++ b/src/App.js
@@ -6,18 +6,22 @@ import BoardPage from "./pages/BoardPage";
 import AdminPage from "./pages/AdminPage";
 import MyPageRoutes from "./routes/MyPageRoutes";
 import NotFound from "./components/base/NotFound";
+import SearchContainer from "./containers/search/SearchContainer";
 
 const App = () => {
     return (
-        <Routes>
-            <Route path="/" element={<BoardListPage/>}/>
-            <Route path="/auth/*" element={<AuthRoutes/>}/>
-            <Route path="/write" element={<WritePage/>}/>
-            <Route path="/boards/:boardId" element={<BoardPage/>}/>
-            <Route path="/mypage/*" element={<MyPageRoutes/>}/>
-            <Route path="/admin" element={<AdminPage/>}/>
-            <Route path="*" element={<NotFound/>}/>
-        </Routes>
+        <>
+            <SearchContainer/>
+            <Routes>
+                <Route path="/" element={<BoardListPage/>}/>
+                <Route path="/auth/*" element={<AuthRoutes/>}/>
+                <Route path="/write" element={<WritePage/>}/>
+                <Route path="/boards/:boardId" element={<BoardPage/>}/>
+                <Route path="/mypage/*" element={<MyPageRoutes/>}/>
+                <Route path="/admin" element={<AdminPage/>}/>
+                <Route path="*" element={<NotFound/>}/>
+            </Routes>
+        </>
     )
 };
 

--- a/src/components/base/Header.js
+++ b/src/components/base/Header.js
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+import Search from "../search/Search";
+import {Link, useLocation} from "react-router-dom";
+
+const HeaderBlock = styled.div`
+  width: 1440px;
+  margin: 20px auto;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  font-family: 'Tilt Neon', sans-serif;
+
+  .logo {
+    padding-left: 80px;
+    font-size: 34px;
+    font-weight: bolder;
+    color: #000;
+  }
+
+  .login {
+    padding-right: 80px;
+    color: #000;
+    font-size: 22px;
+    font-weight: bold;
+  }
+`;
+
+const Header = ({keyword, search, searchError, searchLoading, onChangeKeyword, onSearchKeyword, onNavigateDetail}) => {
+    const {pathname} = useLocation();
+
+    return (
+        <HeaderBlock>
+            <Link className='logo' to='/'>Wasabi</Link>
+            {pathname === '/auth/login' ? null : (
+                <>
+                    <Search keyword={keyword}
+                            search={search}
+                            searchError={searchError}
+                            searchLoading={searchLoading}
+                            onChangeKeyword={onChangeKeyword}
+                            onSearchKeyword={onSearchKeyword}
+                            onNavigateDetail={onNavigateDetail}
+                    />
+                    <Link className='login' to='/auth/login'>로그인</Link>
+                </>
+            )}
+        </HeaderBlock>
+    );
+};
+
+export default Header;

--- a/src/components/boards/AllBoardList.js
+++ b/src/components/boards/AllBoardList.js
@@ -8,28 +8,25 @@ const SelectBox = styled.select`
 
 `;
 
-const AllBoardList = ({boards, boardsError, keyword, search, searchError, boardListLoading, searchKeywordLoading, onSelectFilter, onChangeKeyword, onSearchKeyword, onNavigateDetail}) => {
+const AllBoardList = ({boards, boardsError, boardsLoading, search, searchError, searchLoading, onSelectFilter, onNavigateDetail}) => {
     if (boardsError) {
-        return <div>에러 발생!</div>
+        return <div>게시글 목록 조회 에러 발생!</div>
+    }
+
+    if (searchError) {
+        return <div>키워드 검색 조회 에러 발생!</div>
     }
 
     return (
         <>
-            <input name="keyword"
-                   value={keyword}
-                   placeholder="검색할 키워드를 입력하세요."
-                   onChange={e => onChangeKeyword(e)}
-                   onKeyUp={onSearchKeyword}
-            />
             <SelectBox onChange={e => onSelectFilter(e)}>
                 <option value="">== 정렬 기준 ==</option>
                 <option key="latest" value="latest">최신순</option>
                 <option key="likes" value="likes">좋아요순</option>
                 <option key="views" value="views">조회수순</option>
             </SelectBox>
-            {
-                search ? <BoardList boards={search} loading={searchKeywordLoading} onNavigateDetail={onNavigateDetail}/> :
-                    <BoardList boards={boards} loading={boardListLoading} onNavigateDetail={onNavigateDetail}/>
+            { search ? <BoardList boards={search} loading={searchLoading} onNavigateDetail={onNavigateDetail}/> :
+                <BoardList boards={boards} loading={boardsLoading} onNavigateDetail={onNavigateDetail}/>
             }
         </>
     );

--- a/src/components/search/Search.js
+++ b/src/components/search/Search.js
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import {BsSearch} from "react-icons/bs";
+
+const SearchBlock = styled.div`
+  width: 768px;
+  height: 58px;
+  border: 1px solid gray;
+  border-radius: 6px;
+  text-align: center;
+`;
+
+const StyledInput = styled.input`
+  width: 90%;
+  height: 90%;
+  border: none;
+  margin-left: 12px;
+  font-size: 26px;
+  
+  &:focus {
+    outline: none;
+  }
+`;
+
+const Search = ({keyword, search, searchError, searchLoading, onChangeKeyword, onSearchKeyword, onNavigateDetail}) => {
+    return (
+        <SearchBlock>
+            <BsSearch style={{fontSize: "20px"}}/>
+            <StyledInput name="keyword"
+                         value={keyword}
+                         placeholder="검색할 키워드를 입력하세요."
+                         onChange={e => onChangeKeyword(e)}
+                         onKeyUp={onSearchKeyword}
+            />
+        </SearchBlock>
+    );
+};
+
+export default Search;

--- a/src/containers/boards/AllBoardListContainer.js
+++ b/src/containers/boards/AllBoardListContainer.js
@@ -1,61 +1,39 @@
 import AllBoardList from "../../components/boards/AllBoardList";
 import {useDispatch, useSelector} from "react-redux";
-import {useCallback, useEffect} from "react";
+import {useEffect} from "react";
 import {boardList} from "../../modules/boards";
 import {useSearchParams} from "react-router-dom";
-import {changeField, searchKeyword} from "../../modules/search";
 
 const AllBoardListContainer = () => {
     const [searchParams] = useSearchParams();
     const condition = searchParams.get('sortBy');
     const dispatch = useDispatch();
-    const {boards, boardsError, keyword, search, searchError, boardListLoading, searchKeywordLoading} = useSelector(({boards, search, loading}) => ({
+    const {boards, boardsError, boardsLoading, search, searchError, searchLoading} = useSelector(({boards, search, loading}) => ({
         boards: boards.boards,
         boardsError: boards.boardsError,
-        keyword: search.keyword,
+        boardsLoading: loading['boards/BOARD_LIST'],
         search: search.search,
         searchError: search.searchError,
-        boardListLoading: loading['boards/BOARD_LIST'],
-        searchKeywordLoading: loading['search/SEARCH_KEYWORD'],
+        searchLoading: loading['search/SEARCH_KEYWORD'],
     }));
 
     useEffect(() => {
         dispatch(boardList(condition));
     }, [dispatch, condition]);
 
-    const onSelectFilter = (e) => {
+    const onSelectFilter = e => {
         const value = e.target.options[e.target.selectedIndex].value;
         dispatch(boardList(value));
     };
 
-    const onChangeKeyword = e => {
-        dispatch(changeField({
-                key: 'keyword',
-                value: e.target.value,
-            }),
-        );
-    };
-
-    const onSearchKeyword = useCallback(
-        e => {
-            if (e.key === 'Enter') {
-                dispatch(searchKeyword(keyword));
-            }
-        },
-        [dispatch, keyword]
-    );
-
     return (
         <AllBoardList boards={boards}
                       boardsError={boardsError}
-                      keyword={keyword}
+                      boardsLoading={boardsLoading}
                       search={search}
                       searchError={searchError}
-                      boardListLoading={boardListLoading}
-                      searchKeywordLoading={searchKeywordLoading}
+                      searchLoading={searchLoading}
                       onSelectFilter={onSelectFilter}
-                      onChangeKeyword={onChangeKeyword}
-                      onSearchKeyword={onSearchKeyword}
         />
     );
 };

--- a/src/containers/search/SearchContainer.js
+++ b/src/containers/search/SearchContainer.js
@@ -1,0 +1,43 @@
+import {useDispatch, useSelector} from "react-redux";
+import {changeField, searchKeyword} from "../../modules/search";
+import {useCallback} from "react";
+import Header from "../../components/base/Header";
+
+const SearchContainer = () => {
+    const dispatch = useDispatch();
+    const {keyword, search, searchError, searchLoading} = useSelector(({search, loading}) => ({
+        keyword: search.keyword,
+        search: search.search,
+        searchError: search.searchError,
+        searchLoading: loading['search/SEARCH_KEYWORD'],
+    }));
+
+    const onChangeKeyword = e => {
+        dispatch(changeField({
+                key: 'keyword',
+                value: e.target.value,
+            }),
+        );
+    };
+
+    const onSearchKeyword = useCallback(
+        e => {
+            if (e.key === 'Enter') {
+                dispatch(searchKeyword(keyword));
+            }
+        },
+        [dispatch, keyword]
+    );
+
+    return (
+        <Header keyword={keyword}
+                search={search}
+                searchError={searchError}
+                searchLoading={searchLoading}
+                onChangeKeyword={onChangeKeyword}
+                onSearchKeyword={onSearchKeyword}
+        />
+    );
+};
+
+export default SearchContainer;


### PR DESCRIPTION
> 기존
- 키워드를 검색하는 입력창이 전체 게시글 목록 조회 컴포넌트(AllBoardList)의 자식 컴포넌트였음

> 현재
- 키워드를 검색하는 입력창이 헤더의 자식 컴포넌트로 들어가면서 Search, SearchContainer 컴포넌트를 생성하여 기존 AllBoardList로부터 입력창을 분리함
- `useLocation`을 사용하여 경로가 /auth/login일 때는 로고만 보여지도록 해놓음

> 추후
- 상황에 따라 보여지는 헤더가 여러 개 존재하는데, 상황에 따라 보여지는 헤더 달라지도록 수정
1. 로고
2. 로고, 검색창, 로그인
3. 로고, 검색창, 글쓰기, 사용자이름
4.  로고, 사용자이름
5. 로고, 글쓰기, 사용자이름