### PR TITLE
fix: localStorage 저장 문제 해결

### DIFF
--- a/src/containers/auth/LoginForm.js
+++ b/src/containers/auth/LoginForm.js
@@ -2,7 +2,6 @@ import AuthForm from "../../components/auth/AuthForm";
 import {useDispatch, useSelector} from "react-redux";
 import {changeField, initializeForm, login} from "../../modules/auth";
 import {useEffect} from "react";
-import client from "../../lib/api/client";
 import {useNavigate} from "react-router-dom";
 
 const LoginForm = () => {
@@ -26,30 +25,32 @@ const LoginForm = () => {
         );
     };
 
+    /*
+    async function afterLogin() {
+        await new Promise((resolve) => {
+            if(loading === false) {
+                resolve();
+            }
+        });
+
+        if (auth) {
+            navigate('/');
+        } else if(authError) {
+            alert('로그인 실패');
+        }
+    }
+    */
+
     const onSubmit = () => {
         const {email, password} = form;
         dispatch(login({email, password}));
-        dispatch(initializeForm('login'));
         navigate('/');
+        // afterLogin().then();
     };
 
     useEffect(() => {
         dispatch(initializeForm('login'));
     }, [dispatch]);
-
-    useEffect(() => {
-        if (auth) {
-            try {
-                localStorage.setItem('member', JSON.stringify(auth));
-                client.defaults.headers.common['Authorization'] = `Bearer ${auth}`;
-            } catch (e) {
-                console.log('localStorage is not working.');
-            }
-        }
-        if (authError) {
-            alert('로그인 실패!');
-        }
-    }, [auth, authError, navigate]);
 
     return (
         <AuthForm type="login"

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -3,6 +3,7 @@ import {produce} from "immer";
 import createRequestSaga, {createRequestActionTypes} from "../lib/createRequestSaga";
 import * as authAPI from "../lib/api/auth";
 import {takeLatest} from "redux-saga/effects";
+import client from "../lib/api/client";
 
 const CHANGE_FIELD = 'auth/CHANGE_FIELD';
 const INITIALIZE_FORM = 'auth/INITIALIZE_FORM';
@@ -82,11 +83,18 @@ const auth = handleActions(
             ...state,
             authError: error
         }),
-        [LOGIN_SUCCESS]: (state, {payload: auth}) => ({
-            ...state,
-            auth,
-            authError: null,
-        }),
+        [LOGIN_SUCCESS]: (state, {payload: auth}) => {
+            try {
+                localStorage.setItem('member', JSON.stringify(auth));
+                client.defaults.headers.common['Authorization'] = `Bearer ${auth}`;
+            } catch (e) {
+                console.log('localStorage is not working.');
+            }
+            return {
+                ...state,
+                auth,
+            }
+        },
         [LOGIN_FAILURE]: (state, {payload: error}) => ({
             ...state,
             authError: error


### PR DESCRIPTION
>  문제 상황
- 회원가입 후 로그인을 누르면 로그인 페이지로 이동하는 것이 아닌 `~~님` 으로 변경 (로그인하지도 않았는데..)
- localStorage에 login 응답 데이터가 아닌 signup 응답 데이터가 저장

>  원인
- 결론부터 말하자면, **LoginForm에서 useEffect의 두 번째 매개변수인 auth, authError, navigate가 변경될 때마다 실행되는 코드**가 문제 상황을 야기
1. 회원가입 요청에 성공하면 응답 데이터가 auth에 저장
2. 로그인을 누르면 LoginForm이 렌더링 되고 이때, 1번에서 auth의 변경이 있으므로 useEffect의 코드(localStorage에 auth를 저장)가 실행
3. 이 때문에 회원가입 후에 로그인을 누르면 localStorage에 회원가입 응답 데이터를 담고 있는 auth가 저장되고,
4. MainHeader에서는 localStorage에 저장된 정보가 있으면 그 정보의 이름으로 표시하는 데, 3번에 의해 로그인을 하지 않았는데도 `~~님`으로 뜨게 되는 것

>  해결 방안
1. **localStorage에 응답 데이터 저장하는 조건 변경 (회원가입, 로그인 모두 끝나고 auth가 존재하면 저장)** ❌
![image](https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/50f82419-b49a-4cd0-90ba-5240d7a05abc)
=> 회원가입 후 로그인하는 사용자는 정상적으로 동작하지만, 기존 회원인 경우 회원가입하지 않고 바로 로그인 하므로 `!signupLoading` 조건을 만족 시키지 못해 정상적인 동작이 불가능하다는 문제가 있음

2. **회원가입 후 스토어에 저장된 auth 정보 지우기 (상태 직접 변경)** ❌❌❌❌❌
![image](https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/2889b3b2-1faf-41ec-a3e5-4a5c6950c7a3)
![image](https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/3f5c910a-8d3a-4769-80fc-1d135d31d88d)
=> 리액트는 불변성을 유지하는 것을 중요시 하는데 상태를 직접 변경하면 불변성이 깨질 수 있다는 문제가 있음
=> 리덕스는 상태 변화를 예측 가능하게 만들어 애플리케이션의 상태를 추적하기 쉽게 하는데, 직접 상태를 변경하면 상태 변화가 예측 불가능해짐
=> 리듀서 함수는 순수 함수여야 하는데, 상태를 직접 변경하면 리듀서 함수가 순수성을 유지할 수 없게 됨
(순수 함수 : 같은 입력에 대해서 항상 같은 결과를 반환)

3. **auth 모듈에서 회원가입, 로그인 응답 데이터 구분하여 저장** ⭕️
![image](https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/b7a9ea91-5710-4c3a-b52c-59cf6c99ef41)
=> 좋은 방법인 거 같긴 하나, 이로 인해 auth를 사용하는 코드를 전부 수정해야 하므로 굳이 구분해야 할까라는 의문이 듦

4. **로그인에 성공했을 때만 localStorage에 저장** ⭕️
`LOGIN_SUCCESS` 액션이 발생했을 때, 업데이트 함수에 localStorage에 저장하는 로직을 넣어줌
=> 회원가입은 전혀 고려하지 않아도 되므로 이 방법을 채택!
