### PR TITLE
style: button type 지정 및 AuthForm 스타일링

### DIFF
--- a/src/components/auth/AuthForm.js
+++ b/src/components/auth/AuthForm.js
@@ -1,63 +1,7 @@
-import Button from "../common/Button";
-import styled from "styled-components";
 import {Link} from "react-router-dom";
 import {useForm} from "react-hook-form";
-import {useRef} from "react";
+import {useRef, useState} from "react";
 import SignUpModal from "./SignUpModal";
-
-const AuthFormBlock = styled.div`
-    align-items: center; /* 수직 중앙 정렬 */
-    display: flex; /* 내부 내용 중앙 정렬 */
-    flex-direction: column; /* 플렉스 내의 아이템 배치 */
-    margin-top: 200px;
-
-    div {
-        margin-bottom: 4rem;
-    }
-
-    h3 {
-        margin-bottom: 10px;
-    }
-`;
-
-const StyledInput = styled.input`
-    width: 350px;
-    height: 35px;
-    border: 0.5px solid darkgrey;
-    border-radius: 2.5px;
-    font-size: 1.215rem;
-    padding: 0.25rem 0 0.25rem 0.1rem;
-`;
-
-const StyledSelect = styled.select`
-    width: 100%;
-    height: 44.33px;
-    border: 0.5px solid darkgrey;
-    border-radius: 2.5px;
-    font-size: 1.215rem;
-    padding: 0.25rem 0 0.25rem 0.1rem;
-`;
-
-const StyledOption = styled.option`
-    width: 100%;
-    box-sizing: border-box;
-    border: 0.5px solid darkgrey;
-    border-radius: 2.5px;
-    font-size: 1.215rem;
-    padding: 0.25rem 0 0.25rem 0.1rem;
-    background-color: ${(props) => (props.selected ? '#4BC75F' : '#FFF')};
-`;
-
-const ErrorText = styled.p`
-    color: #EF616B;
-    margin-top: 0.2rem;
-`;
-
-const Footer = styled.div`
-    margin-top: 30px;
-    text-align: center;
-    font-size: 0.7rem;
-`;
 
 const textMap = {  // 객체
     login: '로그인', // 프로퍼티
@@ -96,158 +40,194 @@ const partMap = [
 ];
 
 const AuthForm = ({type, form, onChange, onSubmit, onKeyPress, onSelectPart, isOpenModal, emailConfirm, handleChangeEmailConfirm, handleSendEmailConfirm}) => {
+    const [isClicked, setIsClicked] = useState(false);
     const text = textMap[type];
     const {register, handleSubmit, watch, formState: {errors}} = useForm();
     const passwordRef = useRef(null);
     passwordRef.current = watch('password');
 
     return (
-      <AuthFormBlock>
-          <h2>{text}</h2>
-          {isOpenModal && <SignUpModal/>}
-          <form onSubmit={handleSubmit(onSubmit)}>
-              <div>
-                  <h3>이메일</h3>
-                  <StyledInput {...register("email",
-                    {
-                        required: '필수 입력 항목입니다.',
-                        pattern: {
-                            value: /^[0-9a-zA-Z]([-_]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/,
-                            message: '이메일 형식이 올바르지 않습니다.'
-                        }
-                    })}
-                               placeholder="이메일"
-                               value={form.email}
-                               onChange={onChange}
-                  />
-                  <ErrorText>{errors.email?.message}</ErrorText>
-              </div>
-              <div>
-                  <input placeholder='인증 번호'
-                         name='emailConfirm'
-                         value={emailConfirm}
-                         onChange={handleChangeEmailConfirm}
-                  />
-                  <button onClick={handleSendEmailConfirm}>전송</button>
-              </div>
-              <div>
-                  <h3>비밀번호</h3>
-                  {type === 'signUp' ?
-                    <p style={{color: '#72757A', fontSize: '1rem', margin: '0.5rem 0'}}>영문, 숫자를 포함한 6자 이상의 비밀번호를
-                        입력하세요.</p> : null}
-                  <StyledInput {...register("password",
-                    {
-                        required: '필수 입력 항목입니다.',
-                        pattern: {
-                            value: /^(?=.*[A-Za-z])(?=.*\d).{6,}$/,
-                            message: '비밀번호는 영문, 숫자를 포함하여 6자 이이어야 합니다.'
-                        }
-                    })}
-                               placeholder="비밀번호"
-                               type="password"
-                               value={form.password}
-                               onChange={onChange}
-                               onKeyUp={onKeyPress}
-                  />
-                  <ErrorText>{errors.password?.message}</ErrorText>
-              </div>
-              {type === 'signUp' && (
-                <>
-                    <div>
-                        <h3>비밀번호 확인</h3>
-                        <StyledInput {...register("checkPassword",
-                          {
-                              required: '필수 입력 항목입니다.',
-                              validate: (value) => {
-                                  if (value === passwordRef.current) {
-                                      return null;
-                                  } else {
-                                      return '비밀번호가 일치하지 않습니다.';
-                                  }
-                              }
-                          })}
-                                     placeholder="비밀번호 확인"
-                                     type="password"
-                                     value={form.checkPassword}
-                                     onChange={onChange}
-                        />
-                        <ErrorText>{errors.checkPassword?.message}</ErrorText>
+        <div className='flex flex-col items-center'>
+            <p className='text-2xl text-text1 font-bold mb-10'>{text}</p>
+            {isOpenModal && <SignUpModal/>}
+            <form className='w-3/12 text-lg text-text2 mb-10' onSubmit={handleSubmit(onSubmit)}>
+                <div className='flex flex-col mb-10'>
+                    <p className='font-semibold mb-1.5'>이메일</p>
+                    <input {...register("email",
+                        {
+                            required: '필수 입력 항목입니다.',
+                            pattern: {
+                                value: /^[0-9a-zA-Z]([-_]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/,
+                                message: '이메일 형식이 올바르지 않습니다.'
+                            }
+                        })}
+                           className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                           placeholder="이메일"
+                           value={form.email}
+                           onChange={onChange}
+                    />
+                    <p className='text-sm text-rose-500 mb-1.5'>{errors.email?.message}</p>
+                    {type === 'signUp' ?
+                        <button className='w-full py-3 text-text4 font-semibold rounded-md bg-gray-100 hover:bg-gray-200'
+                                type='button'
+                                onClick={() => { handleSendEmailConfirm(); setIsClicked(!isClicked);}}
+                        >
+                            이메일 인증하기
+                        </button>
+                        : null
+                    }
+                </div>
+                {isClicked ?
+                    <div className='flex flex-col px-2 py-8 mb-10 text-base bg-gray-100'>
+                        <p className='mb-1.5'>이메일로 전송된 인증코드를 입력해 주세요.</p>
+                        <div className='px-2 py-1 border border-gray-200 bg-background2'>
+                            <input className='border-none focus:outline-none'
+                                   placeholder='인증코드'
+                                   name='emailConfirm'
+                                   value={emailConfirm}
+                                   onChange={handleChangeEmailConfirm}
+                            />
+                            <button className='w-fit float-right px-3 text-white font-semibold rounded-sm bg-brand hover:bg-brandAccent'
+                                    type='button'
+                            >
+                                확인
+                            </button>
+                        </div>
                     </div>
-                    <div>
-                        <h3>이름</h3>
-                        <StyledInput {...register("name", {required: '필수 입력 항목입니다.'})}
-                                     placeholder="이름"
-                                     value={form.name}
-                                     onChange={onChange}
-                        />
-                        <ErrorText>{errors.name?.message}</ErrorText>
-                    </div>
-                    <div>
-                        <h3>전화번호</h3>
-                        <p style={{color: '#72757A', fontSize: '1rem', margin: '0.5rem 0'}}>'-'를 포함하여 입력하세요.</p>
-                        <StyledInput {...register("phoneNumber",
-                          {
-                              required: '필수 입력 항목입니다.',
-                              pattern: {
-                                  value: /^\d{3}-\d{3,4}-\d{4}$/,
-                                  message: '핸드폰 번호 형식이 올바르지 않습니다.'
-                              }
-                          })}
-                                     placeholder="010-1234-5678"
-                                     value={form.phoneNumber}
-                                     onChange={onChange}
-                        />
-                        <ErrorText>{errors.phoneNumber?.message}</ErrorText>
-                    </div>
-                    <div>
-                        <h3>URL</h3>
-                        <StyledInput {...register("referenceUrl")}
-                                     placeholder="URL"
-                                     value={form.referenceUrl}
-                                     onChange={onChange}
-                        />
-                    </div>
-                    <div>
-                        <h3>직군</h3>
-                        <StyledSelect onChange={e => onSelectPart(e)}>
-                            {partMap.map(part => (
-                              <StyledOption name='part'
+                    : null
+                }
+                <div className='flex flex-col mb-10'>
+                    <p className='font-semibold mb-1.5'>비밀번호</p>
+                    {type === 'signUp' ?
+                        <p className='text-sm text-text3 mb-1.5'>영문, 숫자를 포함한 6자 이상의 비밀번호를 입력하세요.</p>
+                        : null
+                    }
+                    <input {...register("password",
+                        {
+                            required: '필수 입력 항목입니다.',
+                            pattern: {
+                                value: /^(?=.*[A-Za-z])(?=.*\d).{6,}$/,
+                                message: '비밀번호는 영문, 숫자를 포함하여 6자 이이어야 합니다.'
+                            }
+                        })}
+                           className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                           placeholder="비밀번호"
+                           type="password"
+                           value={form.password}
+                           onChange={onChange}
+                           onKeyUp={onKeyPress}
+                    />
+                    <p className='text-sm text-rose-500 mb-1.5'>{errors.password?.message}</p>
+                </div>
+                {type === 'signUp' && (
+                    <>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>비밀번호 확인</p>
+                            <input {...register("checkPassword",
+                                {
+                                    required: '필수 입력 항목입니다.',
+                                    validate: (value) => {
+                                        if (value === passwordRef.current) {
+                                            return null;
+                                        } else {
+                                            return '비밀번호가 일치하지 않습니다.';
+                                        }
+                                    }
+                                })}
+                                   className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                   placeholder="비밀번호 확인"
+                                   type="password"
+                                   value={form.checkPassword}
+                                   onChange={onChange}
+                            />
+                            <p className='text-sm text-rose-500 mb-1.5'>{errors.checkPassword?.message}</p>
+                        </div>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>이름</p>
+                            <input {...register("name", {required: '필수 입력 항목입니다.'})}
+                                   className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                   placeholder="이름"
+                                   value={form.name}
+                                   onChange={onChange}
+                            />
+                            <p className='text-sm text-rose-500 mb-1.5'>{errors.name?.message}</p>
+                        </div>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>전화번호</p>
+                            <p className='text-sm text-text3 mb-1.5'>'-'를 포함하여 입력하세요.</p>
+                            <input {...register("phoneNumber",
+                                {
+                                    required: '필수 입력 항목입니다.',
+                                    pattern: {
+                                        value: /^\d{3}-\d{3,4}-\d{4}$/,
+                                        message: '핸드폰 번호 형식이 올바르지 않습니다.'
+                                    }
+                                })}
+                                   className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                   placeholder="010-1234-5678"
+                                   value={form.phoneNumber}
+                                   onChange={onChange}
+                            />
+                            <p className='text-sm text-rose-500 mb-1.5'>{errors.phoneNumber?.message}</p>
+                        </div>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>URL</p>
+                            <input {...register("referenceUrl")}
+                                   className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                   placeholder="URL"
+                                   value={form.referenceUrl}
+                                   onChange={onChange}
+                            />
+                        </div>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>직군</p>
+                            <select className='w-full h-[38px] px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                    onChange={e => onSelectPart(e)}
+                            >
+                                {partMap.map(part => (
+                                    <option className='w-full'
+                                            name='part'
                                             key={part.index}
                                             value={part.value}
                                             disabled={part.disabled}>
-                                  {part.name}
-                              </StyledOption>
-                            ))}
-                        </StyledSelect>
-                    </div>
-                    <div>
-                        <h3>소속</h3>
-                        <StyledInput name="organization"
-                                     placeholder="소속"
-                                     value={form.organization}
-                                     onChange={onChange}
-                        />
-                    </div>
-                    <div>
-                        <h3>한 줄 소개</h3>
-                        <StyledInput name="motto"
-                                     placeholder="한 줄 소개"
-                                     value={form.motto}
-                                     onChange={onChange}
-                        />
-                    </div>
-                </>
-              )}
-              <Button fullwidth="true" style={{height: "40px"}} >{text}</Button>
-          </form>
-          <Footer>
-              {type === 'login' ? (
-                <p>회원이 아니신가요? <Link to="/auth/signup" style={{color: " #4BC75F"}}>회원가입</Link>하러 가기</p>
-              ) : (
-                <p>이미 회원이신가요? <Link to="/auth/login" style={{color: " #4BC75F"}}>로그인</Link>하러 가기</p>
-              )}
-          </Footer>
-      </AuthFormBlock>
+                                        {part.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>소속</p>
+                            <input className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                   placeholder="소속"
+                                   name="organization"
+                                   value={form.organization}
+                                   onChange={onChange}
+                            />
+                        </div>
+                        <div className='flex flex-col mb-10'>
+                            <p className='font-semibold mb-1.5'>한 줄 소개</p>
+                            <input className='w-full px-2 py-1 mb-1.5 border border-border2 rounded-md focus:outline-none focus:border-brand'
+                                   placeholder="한 줄 소개"
+                                   name="motto"
+                                   value={form.motto}
+                                   onChange={onChange}
+                            />
+                        </div>
+                    </>
+                )}
+                <button className='w-full py-2 text-lg text-white font-bold rounded-md bg-brand hover:bg-brandAccent'
+                        type='submit'
+                >
+                    {text}
+                </button>
+            </form>
+            <div className='text-base mb-10'>
+                {type === 'login' ?
+                    <p>회원이 아니신가요? <Link className='text-brand' to="/auth/signup">회원가입</Link>하러 가기</p>
+                    : <p>이미 회원이신가요? <Link className='text-brand' to="/auth/login">로그인</Link>하러 가기</p>
+                }
+            </div>
+        </div>
     );
 };
 


### PR DESCRIPTION
- 변경 전
<img width="1552" alt="스크린샷 2024-01-29 오전 10 42 05" src="https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/4f238aa4-240d-4431-9fa5-df86d716a030">


- 변경 후
1. styled-components ➜ tailwindcss
2. 이메일 인증코드 전송 버튼 위치 변경 (인증코드 입력창 옆 ➜ 이메일 입력창 아래)
3. 이메일 인증하기 버튼 클릭했을 경우 이메일 인증코드 입력창 나타나기
<img width="1552" alt="스크린샷 2024-02-04 오후 3 23 53" src="https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/1e0797f0-8543-4655-bc17-e1dedc82a2f1">
<img width="1552" alt="스크린샷 2024-02-04 오후 3 24 01" src="https://github.com/Wisoft-Wasabi/wasabi-frontend/assets/95853481/7820364e-fc8d-423e-acf2-dee5e6388389">
