### PR TITLE
fix: 게시글 내용 이탈하는 문제 해결

### DIFF
--- a/src/components/board/BoardViewer.js
+++ b/src/components/board/BoardViewer.js
@@ -38,7 +38,7 @@ const BoardViewer = ({board, boardError, loading}) => {
                     <div>{new Date(createdAt).toLocaleString()} •</div>
                     <div>{views}명이 조회했어요.</div>
                 </div>
-                <div className='text-justify text-text2 text-lg'
+                <div className='text-justify text-text2 text-lg overflow-x-auto'
                      dangerouslySetInnerHTML={{__html: content}}
                 /> {/* HTML 적용 */}
             </div>


### PR DESCRIPTION
# 개요
게시글 내용을 길게 작성한 경우 게시글 상세 조회 페이지에서 정해진 크기를 벗어나 작성한 내용들이 가로로 이어지는 문제를 발견하였다.
<br />

# 작업 사항
1. `overflow-x: auto;` 속성을 추가하여 콘텐츠가 div 요소의 가로 크기를 넘어갈 경우 가로 스크롤이 발생하지 않고 세로 스크롤이 발생하도록 설정